### PR TITLE
Website sections missing added

### DIFF
--- a/monero-outreach-docs/en/website-sections/monero-typography_en.md
+++ b/monero-outreach-docs/en/website-sections/monero-typography_en.md
@@ -1,0 +1,68 @@
+# Monero Typography
+
+Monero Outreach | 30/09/18
+You, and only you can prevent typography fires.
+
+Monero's logotype uses a modified Century Gothic. This typeface was released by Monotype in 1991. It was based on Futura which was designed by Paul Renner in 1927.
+
+## Introducing: MoneroGothic
+
+Monero Outreach created MoneroGothic to correct deficiencies, reduce filesize, provide @fontface stacks and widen language support (25 and countless dialects). Our version is released as Creative Commons Share-alike which means that you need acknowledge we're copying Monotype, like they copied from Renner who probably ripped off some lost bauhaus crypto wiz. Available only in bold, for the bold.
+
+*MoneroGothic v3 (12/04/2018)*
+
+Version 3 is a major update that fixes missing and ugly glyphs. We also merged the two Latin character set (W01 & W02) into one file as we were able to sufficiently reduce filesize to be able to enjoy this convenience with a clear conscience.
+
+[MoneroGothic.otf (Desktop)](https://www.monerooutreach.org/fonts/MoneroGothic_v3.zip)
+
+[MoneroGothic (@fontface)](https://www.monerooutreach.org/fonts/MoneroGothic_v3_web.zip)
+
++ Albanian (sq)
+
++ Croatian (hr)
+
++ Czech (cs)
+
++ Danish (da)
+
++ Dutch (nl)
+
++ English (en)
+
++ Estonian (et)
+
++ Finnish (fi)
+
++ French (fr)
+
++ German (de)
+
++ Hungarian (hu)
+
++ Icelandic (is)
+
++ Italian (it)
+
++ Latvian (lv)
+
++ Lithuanian (lt)
+
++ Norwegian (nn)
+
++ Polish (pl)
+
++ Portuguese (pt)
+
++ Romanian (ro)
+
++ Slovak (sk)
+
++ Slovenian (sl)
+
++ Spanish (es)
+
++ Swedish (sv)
+
++ Turkish (tr)
+
++ Welsh (cy)

--- a/monero-outreach-docs/en/website-sections/stellumo-monero-fractal-art_en.md
+++ b/monero-outreach-docs/en/website-sections/stellumo-monero-fractal-art_en.md
@@ -1,0 +1,15 @@
+# Stellumo - Monero Blockchain Fractal Art
+
+Stellumo | 07/11/18 Stellumo renders the Monero blockchain as fractal art.
+
+Further down the rabbit hole we go as we look at how Stellumo represents the entire Monero blockchain as fractal art. Be sure to visit their github page [github.com/monero-ecosystem/Stellumo](https://github.com/monero-ecosystem/Stellumo) to give them some love and see more of their images. Now, without further ado, we'll leave you with Stellumo and Lewis Carroll to see the blockchain in a whole new way.
+
+## *“The name of the song is called ‘Haddocks’ Eyes.”*
+
+## *“Oh, that’s the name of the song, is it?” Alice said, trying to feel interested.*
+
+## *“No, you don’t understand,” the Knight said, looking a little vexed.*
+
+## *“That’s what the name is called.”*
+
+Lewis Carroll from Through the Looking-Glass

--- a/monero-outreach-docs/translations/es/website-sections/monero-typography_es.md
+++ b/monero-outreach-docs/translations/es/website-sections/monero-typography_es.md
@@ -1,0 +1,68 @@
+# Tipografía de Monero
+
+Monero Outreach | 30/09/18
+Tu y solamente tu puedes evitar incendios con la tipografía.
+
+El logotipo de Monero utiliza un Century Gothic modificado. Este tipo de letra fue publicado por Monotype en 1991. Basado sobre Futura el cuál fue diseñado por Paul Renner en 1927.
+
+## Introduciendo: MoneroGothic
+
+Monero Outreach creó MoneroGothic para corregir deficiencias, reducir el tamaño de archivo, proveer variedad de @tipo-de-letra y ampliar la compatibilidad en los lenguajes (25 lenguajes e incontables dialectos). Nuestra versión es publicado con licencia Creative Commons CompartirIgual (Share-alike) lo que quiere decir que debes reconocer que estamos copiando a Monotype, al igual como ellos copiaron de Renner que probablemente se lo arrebato a algún experto desaparecido. Disponible solamente en negrilla.
+
+*MoneroGothic v3 (12/04/2018)*
+
+La tercera versión es una actualización que arregla glifos que hacían falta y con deficiencias. También integramos el conjunto de dos caracteres latinos (W01 y W02) a un solo archivo ya que fuimos pudimos reducir el tamaño del archivo lo suficiente para disfrutar este beneficio con una consciencia limpia. 
+
+[MoneroGothic.otf (Escritorio)](https://www.monerooutreach.org/fonts/MoneroGothic_v3.zip)
+
+[MoneroGothic (@tipo-de-letra)](https://www.monerooutreach.org/fonts/MoneroGothic_v3_web.zip)
+
++ Alemán (de)
+
++ Albanés (sq)
+
++ Checo (cs)
+
++ Croata (hr)
+
++ Danés (da)
+
++ Eslovaco (sk)
+
++ Esloveno (sl)
+
++ Estonio (et)
+
++ Español (es)
+
++ Finlandés (fi)
+
++ Frances (fr)
+
++ Galés (cy)
+
++ Holandés (nl)
+
++ Húngaro (hu)
+
++ Inglés (en)
+
++ Islandés (is)
+
++ Italiano (it)
+
++ Letón (lv)
+
++ Lituano (lt)
+
++ Noruego (nn)
+
++ Polaco (pl)
+
++ Portugues (pt)
+
++ Romano (ro)
+
++ Sueco (sv)
+
++ Turco (tr)

--- a/monero-outreach-docs/translations/es/website-sections/stellumo-monero-fractal-art_es.md
+++ b/monero-outreach-docs/translations/es/website-sections/stellumo-monero-fractal-art_es.md
@@ -1,0 +1,15 @@
+# Stellumo - Arte Fractal al Blockchain de Monero 
+
+Stellumo | 07/11/18 Stellumo representa al blockchain de Monero como arte fractal.
+
+A medida que vamos al fondo del agujero de conejo, vemos como Stellumo representa la blockchain de Monero completa en arte fractal. Asegúrate de visitar su perfil en github, [github.com/monero-ecosystem/Stellumo](https://github.com/monero-ecosystem/Stellumo), para darles amor y ver más de sus imágenes. Ahora, sin tanto alboroto, los dejamos con Stellumo y Lewis Carrol para ver la blockchain de una manera completamente nueva.
+
+## *"- O si no se les ha saltado nada, ésa es la verdad. A la canción la llaman "Ojos de bacalao"."*
+
+## *"¡Ah! ¿Conque ése es el nombre de la canción, eh? - dijo Alicia, intentando dar la impresión de que estaba interesada."*
+
+## *"- No, no comprendes - corrigió el caballero, con no poca contrariedad -. Así es como la llaman, pero su nombre en realidad es "Un anciano viejo viejo"."*
+
+## *"- Entonces, ¿debo decir que así es como se llama la canción? - se corrigió a su vez Alicia."*
+
+Lewis Carroll de A través del espejo

--- a/monero-outreach-docs/translations/pt-br/website-sections/monero-typography_pt_br.md
+++ b/monero-outreach-docs/translations/pt-br/website-sections/monero-typography_pt_br.md
@@ -1,53 +1,68 @@
-## Tipografia Monero
+# Tipografia Monero
+
 Monero Outreach | 30/09/18
 Você, e somente você pode impedir disparos tipográficos.
 
-A "Fonte Monero" é uma modificação da Century Gothic lançada pela Monotype em 1991. Ela foi baseada na Futura, projetada por Paul Renner em 1927. Você poderá notar aqui que o E e o R são diferentes, e também que o O foi levemente alterado.
+O logotipo do Monero utiliza uma modificação da Century Gothic. Essa fonte foi lançada pela Monotype em 1991. Ela foi baseada na Futura, projetada por Paul Renner em 1927
 
-### Apresentando: MoneroGothic.otf
+## Apresentando: MoneroGothic
 
-Essa versão resgata as esquisitices do Monero e glifos foram adicionados para dar suporte a XX idiomas e pacotes de fonte para web foram criados. Nós lançamos nossa versão sob a licença Creative Commons, o que significa devemos reconhecer nos créditos que estamos copiando a Monotype, da mesma forma que eles copiaram o Renner que provavelmente roubou de algum Bauhaus _expert_ em cripto.
+O Monero Outreach criou a MoneroGothic para corrigir deficiências, reduzir o tamanho do arquivo, fornecer pilhas @fontface e ampliar o suporte a outros idiomas (25 e inúmeros dialetos). Nossa versão foi lançada sob a licença Creative Commons Share-alike, o que significa que nós precisamos reconhecer que estamos copiando a Monotype, assim como eles copiaram do Renner, que provavelmente roubou de algum Bauhaus _expert_ em cripto. Disponível apenas em negrito, para os corajosos.
 
-Latim Mínimo (W00)
-- Inglês (en)
+*MoneroGothic v3 (12/04/2018)*
 
-Latim 1 (W01)
-- Galês (cy)
-- Dinamarquês (da)
-- Alemão (de)
-- Inglês (en)
-- Espanhol (es)
--
-- Francês (fr)
-- Italiano (it)
-- Holandês (nl)
-- Norueguês (nn)
-- Albanês (sq)
+A versão 3 é uma atualização importante que corrige glifos ausentes ou simplesmente feios. Nós também unimos os dois conjuntos de caracteres latinos (W01 e W02) em um único arquivo, já que foi possível reduzir seu tamanho de forma suficiente para aproveitar essa conveniência com a consciência tranquila.
 
+[MoneroGothic.otf (Desktop)](https://www.monerooutreach.org/fonts/MoneroGothic_v3.zip)
 
-Latim Extendido 1 (W02)
-- Checo (cs)
-- Estoniano (et)
-- Finlandês (fi)
-- Croata (hr)
-- Húngaro (hu)
-- Islandês (is)
-- Lituano (lt)
--
-- Letão (lv)
-- Polonês (pl)
-- Português (pt)
-- Romeno (ro)
-- Eslovaco (sk)
-- Esloveno (sl)
-- Sueco (sv)
-- Turco (tr)
+[MoneroGothic (@fontface)](https://www.monerooutreach.org/fonts/MoneroGothic_v3_web.zip)
 
-Cirílico (W10)
-- Bielorusso (be)
-- Búlgaro (bg)
-- Russo (ru)
-- Ucraniano (uk)
++ Alemão (de)
 
-Grego (W15) 	
-- Grego (el)
++ Albanês (sq)
+
++ Checo (cs)
+
++ Croata (hr)
+
++ Dinamarquês (da)
+
++ Eslovaco (sk)
+
++ Esloveno (sl)
+
++ Espanhol (es)
+
++ Estoniano (et)
+
++ Finlandês (fi)
+
++ Francês (fr)
+
++ Galês (cy)
+
++ Holandês (nl)
+
++ Húngaro (hu)
+
++ Inglês (en)
+
++ Islandês (is)
+
++ Italiano (it)
+
++ Letão (lv)
+
++ Lituano (lt)
+
++ Norueguês (nn)
+
++ Polonês (pl)
+
++ Português (pt)
+
++ Romeno (ro)
+
++ Sueco (sv)
+
++ Turco (tr)

--- a/monero-outreach-docs/translations/pt-br/website-sections/stellumo-monero-fractal-art_pt_br.md
+++ b/monero-outreach-docs/translations/pt-br/website-sections/stellumo-monero-fractal-art_pt_br.md
@@ -1,13 +1,15 @@
-Stellumo - Arte Fractal do Blockchain Monero
+# Stellumo - Arte Fractal do Blockchain Monero
+
 Stellumo | 07/11/18 Stellumo renderiza o Blockchain Monero em arte fractal.
 
-Quanto mais olhamos em como Stellumo representa o Blockchain inteiro do Monero em arte fractal, mais surreal a situação fica. Lembre-se de dar mais amor a eles visitando a página no github em github.com/monero-ecosystem/Stellumo e para ver mais imagens. Agora, sem mais demora, deixaremos vocês com Stellumo e Lewis Carroll para ver o Blockchain de uma maneira totalmente nova.
+Quanto mais olhamos em como Stellumo representa o Blockchain inteiro do Monero em arte fractal, mais surreal a situação fica. Lembre-se de dar mais amor a eles visitando a página no github em [github.com/monero-ecosystem/Stellumo](https://github.com/monero-ecosystem/Stellumo) e para ver mais imagens. Agora, sem mais demora, deixaremos vocês com Stellumo e Lewis Carroll para ver o Blockchain de uma maneira totalmente nova.
 
-"O nome da canção é chamado 'Olhos de hadoque'."
+## "O nome da canção é chamado 'Olhos de hadoque'."
 
-"Oh, esse é o nome da canção, não é?" disse Alice, tentando se interessar.
+## "Oh, esse é o nome da canção, não é?" disse Alice, tentando se interessar.
 
-"Não, você não entendeu", disse o Cavaleiro um pouco irritado.
+## "Não, você não entendeu", disse o Cavaleiro um pouco irritado.
 
-"É assim que o nome é chamado."
+## "É assim que o nome é chamado."
+
 Lewis Carroll em Através do espelho e o que Alice encontrou por lá


### PR DESCRIPTION
Hi @erciccione,

Added missing files from the website section to the 'en' folder, translated to 'es', and made some changes to the 'pt_br' files. 

Pinging @netrik182, some text from the file monero-typography_pt_br.md was added from the last translation you made https://www.monerooutreach.org/monero-typography.php. 

*"Version 3 is a major update that fixes missing and ugly glyphs. We also merged the two Latin character set (W01 & W02) into one file as we were able to sufficiently reduce filesize to be able to enjoy this convenience with a clear conscience."*

Could you help me out with this translation so I can change it?