### PR TITLE
Adding transcriptions README descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![GitHub repo size](https://img.shields.io/github/repo-size/monero-ecosystem/outreach-docs.svg)
 
+### For [Monerokon](https://www.youtube.com/playlist?list=PLsSYUeVwrHBkJHJg_l2uDgbicDJ1PmAVW) transcriptions click [here](https://github.com/monero-ecosystem/outreach-docs/tree/master/monero-outreach-docs/en/transcriptions/)
+
 # How to contribute
 
 Welcome to the Monero Outreach. This directory contains all the final versions of the documents published by the Monero Outreach Workgroup and the documents of the Monero Meetup Kit. You will also find the translation directory. 

--- a/monero-outreach-docs/en/transcriptions/README.md
+++ b/monero-outreach-docs/en/transcriptions/README.md
@@ -1,0 +1,24 @@
+# Monero Outreach Transcriptions 
+
+Welcome to the Monero Outreach Transcriptions folder. This is a new section inside the workgroup and we are glad to add more activities.
+
+**How to contribute?** 
+
+We are currently working to transcribe the full video talk for the Monero Konferenco 2019 ([Youtube list](https://www.youtube.com/playlist?list=PLsSYUeVwrHBkJHJg_l2uDgbicDJ1PmAVW)) and you will find the `monero-konferenco-2019` folder where you can push your transcriptions. 
+
+We created a [Taiga instance](https://taiga.getmonero.org/project/xmrhaelan-monero-public-relations/epic/169) for the 2019 Monero Konferenco where you can assign yourself one of the different video conference talks and choose from [Day 1 - Saturday Livestream](https://taiga.getmonero.org/project/xmrhaelan-monero-public-relations/us/170) or [Day 2 - Sunday Livestream](https://taiga.getmonero.org/project/xmrhaelan-monero-public-relations/us/171). 
+
+You will also find `breaking_monero` folder with the full [Breaking Monero Series](https://www.youtube.com/playlist?list=PLsSYUeVwrHBnAUre2G_LYDsdo-tD0ov-y) ready for review and translation. For translating and/or review instructions please read the this [README.md](https://github.com/monero-ecosystem/outreach-docs/blob/master/README.md). 
+
+**Transcriptions are currently not in our compensation model** 
+
+## Transcriptions
+
+Work the transcription in md (markdown) file format. Make a PR once you finish the transcription and submit it to the Taiga EPIC of the specific transcription instance. If you need help please open a [New issue](https://github.com/monero-ecosystem/outreach-docs/issues/new) for assistance.
+- Check some samples of md file format transcriptions [here](https://github.com/monero-ecosystem/outreach-docs/tree/master/monero-outreach-docs/en/transcriptions/breaking_monero)
+
+## Resources
+
+- Web: [monerooutreach.org](https://www.monerooutreach.org/)
+- Breaking Monero Transcription: [monerooutreach.org/breaking-monero](https://www.monerooutreach.org/breaking-monero/) 
+- Monero Konferenco 2019: [monerooutreach.org/monero-konferenco](https://www.monerooutreach.org/monero-konferenco/)


### PR DESCRIPTION
Hey @erciccione,

Added the Monero Konferenco 2019 transcription folder with `Day 1` and `Day 2` folders. Added a small description to the front README redirecting anyone who is interested in the MoneroKon transcriptions. I also added a README for the transcriptions folder giving some instructions on how to work them out. 

Here is the taiga instance for the [MoneroKon 2019](https://taiga.getmonero.org/project/xmrhaelan-monero-public-relations/epic/169).

We are planning to look for volunteers but first is better to have this merged. Some transcriptions have already been assign so we are expecting PR at any moment. Let me know if you have any questions or if you would like to add anything to the README files. 

>:)