### PR TITLE
Add CODEOWNERS file in /.github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Default for outreach repo
+*       @lh1008
+
+# for all the meetup-kit stuff
+/meetup-kit/  @erciccione


### PR DESCRIPTION
To automate a bit review requests. See ['about code owners'](https://help.github.com/en/articles/about-code-owners).

Basically: Pull requests editing files in the whole repo will automaticlaly require a review from @lh1008 . PRs opened in `/meetup-kit` will automatically require a review from me. This is a minor thing, but allows me to not manually request a review from lh1008 every time a PR is opened :)
