### PR TITLE
Fixed README link for REAMDE.md translation folder

### DIFF
--- a/monero-outreach-docs/translations/README.md
+++ b/monero-outreach-docs/translations/README.md
@@ -10,7 +10,7 @@ Translate as to many languages all the documentation provided by the Monero Outr
 
 ## IMPORTANT
 
-Read the [README_i18.md](https://github.com/monero-ecosystem/outreach-docs/blob/master/monero-outreach-docs/README_i18n.md) file.
+Read the [README.md](https://github.com/monero-ecosystem/outreach-docs/blob/master/README.md) file.
 
 ### Fonts
 


### PR DESCRIPTION
Hey everyone,

Fixed link (https://github.com/monero-ecosystem/outreach-docs/blob/master/monero-outreach-docs/translations/README.md) from README file from `translations/` folder. Issue #287.

Thanks.